### PR TITLE
try: add state livedata

### DIFF
--- a/livedata/src/main/java/jp/co/fuller/yakan/livedata/StateLiveData.kt
+++ b/livedata/src/main/java/jp/co/fuller/yakan/livedata/StateLiveData.kt
@@ -1,0 +1,68 @@
+package jp.co.fuller.yakan.livedata
+
+import androidx.annotation.MainThread
+import androidx.collection.ArraySet
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.Observer
+
+/**
+ * a subtype of [MediatorLiveData] that emitting value a once.
+ */
+class StateLiveData<T> : MediatorLiveData<T>() {
+
+    private val observers = ArraySet<ObserverWrapper<in T>>()
+
+    @MainThread
+    override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
+        val wrapper = ObserverWrapper(observer)
+        observers.add(wrapper)
+        super.observe(owner, wrapper)
+    }
+
+    @MainThread
+    override fun observeForever(observer: Observer<in T>) {
+        val wrapper = ObserverWrapper(observer)
+        observers.add(wrapper)
+        super.observeForever(wrapper)
+    }
+
+    @MainThread
+    override fun removeObserver(observer: Observer<in T>) {
+        if (observer is ObserverWrapper && observers.remove(observer)) {
+            super.removeObserver(observer)
+            return
+        }
+        val iterator = observers.iterator()
+        while (iterator.hasNext()) {
+            val wrapper = iterator.next()
+            if (wrapper.observer == observer) {
+                iterator.remove()
+                super.removeObserver(wrapper)
+                break
+            }
+        }
+    }
+
+    @MainThread
+    override fun setValue(t: T?) {
+        observers.forEach { it.newValue() }
+        super.setValue(t)
+    }
+
+    private class ObserverWrapper<T>(val observer: Observer<T>) : Observer<T> {
+
+        private var pending = false
+
+        override fun onChanged(t: T?) {
+            if (pending) {
+                pending = false
+                observer.onChanged(t)
+            }
+        }
+
+        fun newValue() {
+            pending = true
+        }
+    }
+}


### PR DESCRIPTION
細かいニュアンスを伝えるために日本語で失礼します🙏

ViewModelに保持するStateの扱いについて考えた結果、以下のような結論に至りました。

### Data(APIから取得したものなど)はStream的にViewに流したい
DataBindingやViewBindingでそのまま値を反映させる
→MutableLiveData, LiveDataなどを使うのが適切

### Stateはワンショット的にViewに流したい
なぜならStateをViewに通知するときは、Stateの変化を契機になんらかのイベントを起こしたい場合が多いため
例：エラー通知
ただし、ViewへのBindingで `isLoading` (≒ `if(state is Loaing) { ... }` ) のように状態を見る場合があるので、値はViewModelに保持しておきたい
→値を保持しないEventLiveDataではない、ワンショットのLiveDataがほしい

そのため、 `StateLiveData` という名前で `ワンショットだが、値は保持するLiveData` を定義してみました。
実装については以下の記事とOSSを参考にしました。
https://github.com/hadilq/LiveEvent
https://proandroiddev.com/livedata-with-single-events-2395dea972a8

扱いがややこしくなりそうであればPRごと捨ててもらっても大丈夫です。
ご確認お願いします。